### PR TITLE
Fix object disposed exception on shell navigation

### DIFF
--- a/BarcodeScanning.Native.Maui/CameraView.cs
+++ b/BarcodeScanning.Native.Maui/CameraView.cs
@@ -251,6 +251,13 @@ public partial class CameraView : View
     /// <param name="e"></param>
     private void CameraView_Unloaded(object sender, EventArgs e)
     {
-        this.Handler?.DisconnectHandler();
+        try // Avoid 'cannot access a disposed object' exception
+        {
+            this.Handler?.DisconnectHandler();
+        }
+        catch (Exception)
+        {
+
+        }
     }
 }


### PR DESCRIPTION
We noticed an expception on shell navigation, when navigation away from a page that contains a cameraview. A try-catch mitigates the issue