### PR TITLE
Cannot access a disposed object. Object name: 'AndroidX.Camera.Core.SettableImageProxy' workaround

### DIFF
--- a/BarcodeScanning.Native.Maui/Platforms/Android/BarcodeAnalyzer.cs
+++ b/BarcodeScanning.Native.Maui/Platforms/Android/BarcodeAnalyzer.cs
@@ -16,11 +16,13 @@ internal class BarcodeAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
     private readonly IBarcodeScanner _barcodeScanner;
     private readonly CameraView _cameraView;
     private readonly PreviewView _previewView;
+    private readonly CameraViewHandler _cameraViewHandler;
 
-    internal BarcodeAnalyzer(CameraView cameraView, PreviewView previewView)
+    internal BarcodeAnalyzer(CameraView cameraView, PreviewView previewView, CameraViewHandler cameraViewHandler)
     {
         _cameraView = cameraView;
         _previewView = previewView;
+        _cameraViewHandler = cameraViewHandler;
 
         _barcodeScanner = Xamarin.Google.MLKit.Vision.BarCode.BarcodeScanning.GetClient(new BarcodeScannerOptions.Builder()
             .SetBarcodeFormats(Methods.ConvertBarcodeFormats(_cameraView.BarcodeSymbologies))
@@ -91,11 +93,11 @@ internal class BarcodeAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
         }
         finally
         {
-            SafeCloseImageProxy(proxy);
+            await SafeCloseImageProxy(proxy, _cameraViewHandler);
         }
     } 
 
-    private static void SafeCloseImageProxy(IImageProxy proxy)
+    private async static Task SafeCloseImageProxy(IImageProxy proxy, CameraViewHandler cameraViewHandler)
     {
         try
         {
@@ -103,7 +105,8 @@ internal class BarcodeAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
         }
         catch (Exception) 
         {
-
+            await Task.Delay(10);
+            await MainThread.InvokeOnMainThreadAsync(() => cameraViewHandler.Start());
         }
     }
 

--- a/BarcodeScanning.Native.Maui/Platforms/Android/BarcodeAnalyzer.cs
+++ b/BarcodeScanning.Native.Maui/Platforms/Android/BarcodeAnalyzer.cs
@@ -35,7 +35,7 @@ internal class BarcodeAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
         {
             if (proxy is null || _cameraView.PauseScanning)
                 return;
-            
+
             var target = await MainThread.InvokeOnMainThreadAsync(() => _previewView.OutputTransform);
             var source = new ImageProxyTransformFactory
             {
@@ -57,7 +57,7 @@ internal class BarcodeAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
 
                 _barcodeResults.UnionWith(Methods.ProcessBarcodeResult(results, coordinateTransform));
             }
-            
+
             if (_cameraView.AimMode)
             {
                 var previewCenter = new Point(_previewView.Width / 2, _previewView.Height / 2);
@@ -93,20 +93,19 @@ internal class BarcodeAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
         }
         finally
         {
-            await SafeCloseImageProxy(proxy, _cameraViewHandler);
+            SafeCloseImageProxy(proxy, _cameraViewHandler);
         }
-    } 
+    }
 
-    private async static Task SafeCloseImageProxy(IImageProxy proxy, CameraViewHandler cameraViewHandler)
+    private static void SafeCloseImageProxy(IImageProxy proxy, CameraViewHandler cameraViewHandler)
     {
         try
         {
             proxy?.Close();
         }
-        catch (Exception) 
+        catch (Exception)
         {
-            await Task.Delay(10);
-            await MainThread.InvokeOnMainThreadAsync(() => cameraViewHandler.Start());
+            MainThread.BeginInvokeOnMainThread(() => cameraViewHandler.Start());
         }
     }
 

--- a/BarcodeScanning.Native.Maui/Platforms/Android/CameraViewHandler.cs
+++ b/BarcodeScanning.Native.Maui/Platforms/Android/CameraViewHandler.cs
@@ -40,7 +40,7 @@ public partial class CameraViewHandler
         return _barcodeView;
     }
 
-    private void Start()
+    public void Start()
     {
         if (_cameraController is not null)
         {
@@ -100,7 +100,7 @@ public partial class CameraViewHandler
         {
             _cameraController.ClearImageAnalysisAnalyzer();
             _barcodeAnalyzer?.Dispose();
-            _barcodeAnalyzer = new BarcodeAnalyzer(VirtualView, _previewView);
+            _barcodeAnalyzer = new BarcodeAnalyzer(VirtualView, _previewView, this);
             _cameraController.SetImageAnalysisAnalyzer(_cameraExecutor, _barcodeAnalyzer);
         }
     }


### PR DESCRIPTION
Workaround for error "Cannot access a disposed object. Object name: 'AndroidX.Camera.Core.SettableImageProxy'" stopping Analyze/scanning on Android.

By when error is thrown restarting handler