### PR TITLE
try-catch when attempting to restart camera handler and during dispose

### DIFF
--- a/BarcodeScanning.Native.Maui/Platforms/Android/BarcodeAnalyzer.cs
+++ b/BarcodeScanning.Native.Maui/Platforms/Android/BarcodeAnalyzer.cs
@@ -92,10 +92,10 @@ internal class BarcodeAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
             {
                 proxy?.Close();
             }
-            catch (Exception) 
+            catch (Exception)
             {
-                MainThread.BeginInvokeOnMainThread(_cameraViewHandler.Start);
+                MainThread.BeginInvokeOnMainThread(() => { try { _cameraViewHandler.Start(); } catch (Exception) { } });
             }
         }
-    } 
+    }
 }

--- a/BarcodeScanning.Native.Maui/Platforms/Android/BarcodeView.cs
+++ b/BarcodeScanning.Native.Maui/Platforms/Android/BarcodeView.cs
@@ -27,12 +27,12 @@ public class BarcodeView : CoordinatorLayout
             LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent)
         };
         _relativeLayout.AddView(previewView);
-        
+
         this.AddView(_relativeLayout);
     }
 
     internal void AddAimingDot()
-    {      
+    {
         var radius = 25;
         var circleBitmap = Bitmap.CreateBitmap(2 * radius, 2 * radius, Bitmap.Config.Argb8888);
         var canvas = new Canvas(circleBitmap);
@@ -56,17 +56,24 @@ public class BarcodeView : CoordinatorLayout
         }
         catch (Exception)
         {
-            
+
         }
     }
 
     protected override void Dispose(bool disposing)
     {
-        this.RemoveAllViews();
-        _relativeLayout.RemoveAllViews();
+        try
+        {
+            this.RemoveAllViews();
+            _relativeLayout.RemoveAllViews();
 
-        _imageView?.Dispose();
-        _relativeLayout?.Dispose();
-        base.Dispose(disposing);
+            _imageView?.Dispose();
+            _relativeLayout?.Dispose();
+            base.Dispose(disposing);
+        }
+        catch (Exception)
+        {
+
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -84,5 +84,3 @@ A list of bindable properties with descriptions can be found in [CameraView.cs](
 
 ## TODO Windows and macOS support
 Windows and macOS are currently unsupported, but support can be added in the future. Vision framework is compatible with macOS so this implementation wouldn't be difficult. For Windows, barcode detection could be supported through [Zxing.Net](https://github.com/micjahn/ZXing.Net) project.
-
-test

--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ A list of bindable properties with descriptions can be found in [CameraView.cs](
 
 ## TODO Windows and macOS support
 Windows and macOS are currently unsupported, but support can be added in the future. Vision framework is compatible with macOS so this implementation wouldn't be difficult. For Windows, barcode detection could be supported through [Zxing.Net](https://github.com/micjahn/ZXing.Net) project.
+
+test


### PR DESCRIPTION
Sometimes Analyze() would still attempt to call CameraViewHandler.Start() in its catch after a cameraView had been removed. This would cause a crash since CameraController in the handler had already been disposed.
Also rarely in CameraView.Dispose would throw, since it had already been disposed.