### PR TITLE
Update LayoutSubviews BarcodeView to prevent NullReferenceException

### DIFF
--- a/BarcodeScanning.Native.Maui/Platform/MaciOS/BarcodeView.cs
+++ b/BarcodeScanning.Native.Maui/Platform/MaciOS/BarcodeView.cs
@@ -20,13 +20,20 @@ public class BarcodeView : UIView
     {
         base.LayoutSubviews();
 
-        if (_previewLayer is not null)
-            _previewLayer.Frame =  this.Layer.Bounds;
-        if (_shapeLayer is not null)
-            _shapeLayer.Position = new CGPoint(this.Layer.Bounds.Width / 2, this.Layer.Bounds.Height / 2);
+        var layer = this.Layer;
+        var window = this.Window;
+        if (window is null || layer is null) {
+            return;
+        }
 
-        if (_previewLayer?.Connection is not null && _previewLayer.Connection.SupportsVideoOrientation)
-            _previewLayer.Connection.VideoOrientation = this.Window.WindowScene?.InterfaceOrientation switch
+        if (_previewLayer is not null)
+            _previewLayer.Frame =  layer.Bounds;
+        if (_shapeLayer is not null)
+            _shapeLayer.Position = new CGPoint(layer.Bounds.Width / 2, layer.Bounds.Height / 2);
+
+        var previewLayerConnection = _previewLayer?.Connection;
+        if (previewLayerConnection is not null && previewLayerConnection.SupportsVideoOrientation)
+            previewLayerConnection.VideoOrientation = window.WindowScene?.InterfaceOrientation switch
             {
                 UIInterfaceOrientation.LandscapeLeft => AVCaptureVideoOrientation.LandscapeLeft,
                 UIInterfaceOrientation.LandscapeRight => AVCaptureVideoOrientation.LandscapeRight,


### PR DESCRIPTION
Added a couple of extra null checking mechanisms because sometimes a `NullReferenceException` is thrown on iOS when switching back-and-fort to a page with the barcode scanner.

Stacktrace:
```
System.NullReferenceException: Arg_NullReferenceException
     in void BarcodeView.LayoutSubviews()
     in int UIApplication.UIApplicationMain(int, string[], IntPtr, IntPtr)
     in void UIApplication.Main(string[], Type, Type)
     in void Application.Main(string[] args)
```