### PR TITLE
Fix possible NullReferenceException in CaptureDeviceLock on iOS

### DIFF
--- a/BarcodeScanning.Native.Maui/Platform/MaciOS/CameraManager.cs
+++ b/BarcodeScanning.Native.Maui/Platform/MaciOS/CameraManager.cs
@@ -356,7 +356,7 @@ internal class CameraManager : IDisposable
                 }
                 finally
                 {
-                    _captureDevice.UnlockForConfiguration();
+                    _captureDevice?.UnlockForConfiguration();
                 }
             }
         });


### PR DESCRIPTION
Added null coalescing operator in CaptureDeviceLock on iOS to fix a possible NullReferenceException that could be triggered due to a race condition.

Stacktrace:
```
System.NullReferenceException: Arg_NullReferenceException
  ?, in void CameraManager.CaptureDeviceLock(Action action)+() => { }
  ?, in void DispatchQueue.static_dispatcher_to_managed(IntPtr context)
  ?, in int UIApplication.UIApplicationMain(int, string[], IntPtr, IntPtr)
  ?, in void UIApplication.Main(string[], Type, Type)
  ?, in void Application.Main(string[] args)
  ?, in int UIApplication.UIApplicationMain(int, string[], IntPtr, IntPtr)
  ?, in void UIApplication.Main(string[], Type, Type)
  ?, in void Application.Main(string[] args)
```