### PR TITLE
Update BarcodeView for iOS to prevent NullRefrenceException

### DIFF
--- a/BarcodeScanning.Native.Maui/Platform/MaciOS/BarcodeView.cs
+++ b/BarcodeScanning.Native.Maui/Platform/MaciOS/BarcodeView.cs
@@ -31,8 +31,9 @@ public class BarcodeView : UIView
             {
                 _previewLayer.Frame = layer.Bounds;
 
-                if (_previewLayer.Connection is not null && _previewLayer.Connection.SupportsVideoOrientation)
-                    _previewLayer.Connection.VideoOrientation = this.Window?.WindowScene?.InterfaceOrientation switch
+                var connection = _previewLayer.Connection;
+                if (connection is not null && connection.SupportsVideoOrientation)
+                    connection.VideoOrientation = this.Window?.WindowScene?.InterfaceOrientation switch
                     {
                         UIInterfaceOrientation.LandscapeLeft => AVCaptureVideoOrientation.LandscapeLeft,
                         UIInterfaceOrientation.LandscapeRight => AVCaptureVideoOrientation.LandscapeRight,


### PR DESCRIPTION
`BarcodeView.LayoutSubView()` still sporadically produces `System.NullReferenceException`. It looks some kind of race condition. Besides the `_previewLayer.Connection` I don't see why it throws a null ref exception. I updated the code to create a local copy of the `_previewLayer.Connection`. Hopefully this is it.

**Stacktrace**
Unfortunately, the app is build in Release mode, so the line numbers are lost.
```void BarcodeView.LayoutSubviews()
int UIApplication.UIApplicationMain(int, string[], IntPtr, IntPtr)
void UIApplication.Main(string[], Type, Type)
void Application.Main(string[] args)```

**Background**
I've got an app that is intensively used by about 55 different users on a daily basis. About one to four times a day the app crashes with this null ref exception. The app already uses the latest 1.5.7 version of the library. It's much better since the release of PR #78, but the issue still remains. It occurs on different devices, ranging from iPhone 8 to 14 with iOS 15.8.2 to 17.6.1. 
 