### PR TITLE
Fixed null reference exception that occurs when hashing `BarCodeResult`

### DIFF
--- a/BarcodeScanning.Native.Maui/Shared/BarcodeResult.cs
+++ b/BarcodeScanning.Native.Maui/Shared/BarcodeResult.cs
@@ -31,6 +31,6 @@ public class BarcodeResult : IEquatable<BarcodeResult>
     }
     public override int GetHashCode()
     {
-        return this.DisplayValue.GetHashCode();
+        return this.DisplayValue?.GetHashCode() ?? 0;
     }
 }


### PR DESCRIPTION
Fixed null reference exception that occurs when hashing `BarCodeResult` instances without a display value.

These exceptions have been observed on iOS devices:

```
*** Terminating app due to uncaught exception 'System.NullReferenceException', reason: 'Object reference not set to an instance of an object. (System.NullReferenceException)
   at BarcodeScanning.BarcodeResult.GetHashCode()
   at System.Collections.Generic.HashSet`1[[BarcodeScanning.BarcodeResult, BarcodeScanning.Native.Maui, Version=1.5.8.0, Culture=neutral, PublicKeyToken=null]].AddIfNotPresent(BarcodeResult value, Int32& location)
   at BarcodeScanning.Methods.ProcessBarcodeResult(VNBarcodeObservation[] inputResults, HashSet`1 outputResults, AVCaptureVideoPreviewLayer previewLayer)
   at BarcodeScanning.BarcodeAnalyzer.<.ctor>b__4_0(VNRequest request, NSError error)
   at ObjCRuntime.Trampolines.SDVNRequestCompletionHandler.Invoke(IntPtr block, NativeHandle request, NativeHandle error) in /Users/builder/azdo/_work/1/s/xamarin-macios/src/build/dotnet/ios/generated-sources/ObjCRuntime/Trampolines.g.cs:line 50766
   at Vision.VNSequenceRequestHandler.Perform(VNRequest[] requests, CMSampleBuffer sampl<…>
```
