### PR TITLE
Fix ScanFromImageAsync

### DIFF
--- a/BarcodeScanning.Native.Maui/Platform/NET/Methods.cs
+++ b/BarcodeScanning.Native.Maui/Platform/NET/Methods.cs
@@ -2,8 +2,8 @@
 
 public static partial class Methods
 {
-    public static Task<HashSet<BarcodeResult>> ScanFromImageAsync(byte[] imageArray) => throw new NotImplementedException();
-    public static Task<HashSet<BarcodeResult>> ScanFromImageAsync(FileResult file) => throw new NotImplementedException();
-    public static Task<HashSet<BarcodeResult>> ScanFromImageAsync(string url) => throw new NotImplementedException();
-    public static Task<HashSet<BarcodeResult>> ScanFromImageAsync(Stream stream) => throw new NotImplementedException();
+    public static Task<IReadOnlySet<BarcodeResult>> ScanFromImageAsync(byte[] imageArray) => throw new NotImplementedException();
+    public static Task<IReadOnlySet<BarcodeResult>> ScanFromImageAsync(FileResult file) => throw new NotImplementedException();
+    public static Task<IReadOnlySet<BarcodeResult>> ScanFromImageAsync(string url) => throw new NotImplementedException();
+    public static Task<IReadOnlySet<BarcodeResult>> ScanFromImageAsync(Stream stream) => throw new NotImplementedException();
 }


### PR DESCRIPTION
Fix for issue https://github.com/afriscic/BarcodeScanning.Native.Maui/issues/135.
The return types of the Methods class in NET haven't been changed to Task<IReadOnlySet<BarcodeResult>>. Because of this, the platform specific implementations for iOS and Android can't be found at runtime.