### PR TITLE
Fix: Clear Android PreviewView on Start() to remove stale cached image

### DIFF
--- a/BarcodeScanning.Native.Maui/Platform/Android/CameraManager.cs
+++ b/BarcodeScanning.Native.Maui/Platform/Android/CameraManager.cs
@@ -1,6 +1,7 @@
 using Android;
 using Android.Content;
 using Android.Graphics;
+using Android.Views;
 using Android.Widget;
 using AndroidX.Camera.Core;
 using AndroidX.Camera.Core.ResolutionSelector;
@@ -121,7 +122,9 @@ internal class CameraManager : IDisposable
     }
 
     internal void Start()
-    { 
+    {
+        ClearPreview();
+
         if (_previewView is not null)
             _previewView.Controller = null;
 
@@ -261,6 +264,16 @@ internal class CameraManager : IDisposable
         }
     }
     
+    public void ClearPreview() {
+        if (_previewView?.GetChildAt(0) is TextureView textureView) {
+            var canvas = textureView.LockCanvas();
+            if (canvas != null) {
+                canvas.DrawColor(Android.Graphics.Color.Black);
+                textureView.UnlockCanvasAndPost(canvas);
+            }
+        }
+    }
+
     public void Dispose()
     {
         Dispose(true);


### PR DESCRIPTION
Thank you very much for this great project! It fills a much needed purpose. With the alternative ZXing package, I could not shut off the camera at all on Android once it starts, so this is much better. I also appreciate that your code is much more clear and concise.

With that said, there is one visual glitch I have observed on Android, and I have thus proposed this fix to correct it.

### FIX OVERVIEW:
In Android, the `PreviewView` exhibits a visual glitch when restarting the scanner via `cameraView.CameraEnabled = true`:

1. It briefly shows a stale (cached) camera frame
2. Then it goes black
3. Then it displays the correct live preview

This fix adds a small function in Android to clear the inner `TextureView` inside `PreviewView` during `Start()`, which prevents that stale frame from flashing. This results in a smoother visual transition.

### TEST CODE:

You can demonstrate the current visual glitch behavior by toggling `cameraView.CameraEnabled = false` & `cameraView.CameraEnabled = true` on an Android phone (tested with Samsung phone). Each time it is enabled, it will momentarily show the old stale cached last frame from before it was re-enabled.

This can be worked around with a static reflection method like:

```
public class MyQRScannerNative : BarcodeScanning.CameraView {
    public void WipePreviewView() {
#if ANDROID
        try {
            var handler = this.Handler;
            if (handler == null) return;

            var cameraManagerField = handler.GetType().GetField("_cameraManager", BindingFlags.NonPublic | BindingFlags.Instance);
            var cameraManager = cameraManagerField?.GetValue(handler);
            if (cameraManager == null) return;

            var previewViewField = cameraManager.GetType().GetField("_previewView", BindingFlags.NonPublic | BindingFlags.Instance);
            var previewView = previewViewField?.GetValue(cameraManager) as AndroidX.Camera.View.PreviewView;
            if (previewView == null) return;

            // Now blank inner child (IT IS A TEXTURE VIEW DURING TEST OUTPUT, NOT SURFACE VIEW)
            var innerView = previewView.GetChildAt(0);
            if (innerView is Android.Views.TextureView textureView) {
                Debug.WriteLine("QR FOUND TEXTURE VIEW");
                var canvas = textureView.LockCanvas();
                if (canvas != null) {
                    canvas.DrawColor(Android.Graphics.Color.Black); 
                    textureView.UnlockCanvasAndPost(canvas);
                    Debug.WriteLine("WipePreviewView", "TextureView wiped.");
                }
            }
            // Theoretically to test if it can be a SurfaceView (does not appear to be)
            else if (innerView is Android.Views.SurfaceView surfaceView) {
                Debug.WriteLine("QR FOUND SURFACE VIEW");
                var holder = surfaceView.Holder;
                if (holder?.Surface != null && holder.Surface.IsValid) {
                    var canvas = holder.LockCanvas();
                    if (canvas != null) {
                        canvas.DrawColor(Android.Graphics.Color.Black);
                        holder.UnlockCanvasAndPost(canvas);
                        Debug.WriteLine("WipePreviewView", "SurfaceView wiped.");
                    }
                }
            }
            else {
                Debug.WriteLine("WipePreviewView", $"Unknown view type: {innerView?.GetType()?.Name}");
            }
        }
        catch (Exception ex) {
            Android.Util.Log.Warn("WipePreviewView", $"Error while blanking preview: {ex}");
        }
#endif
    }
}
```

This static workaround can be used with the derived class by running on our showing logic:

```
barReaderNative.WipePreviewView();
barReaderNative.CameraEnabled = true;
```
And we no longer have this visual glitch. It does not seem to provide any benefit to run it on the `CameraEnabled = false` instead.

### ANDROID DESIGN:

This fix follows from the Android hierarchy, which is:
```
//=========================
// ANDROID HIERARCHY:
//=========================
//   CameraView(MAUI virtual view)
//    └ BarcodeView(native Android view)
//        └ RelativeLayout(_relativeLayout)
//            └ PreviewView(_previewView) ← 📷 CAMERA FEED RENDERED INTO TEXTURE VIEW INSIDE HERE
```

### CODE FIX:

The difference required to apply this fix is then very minimal. We see [in CameraViewHandler](https://raw.githubusercontent.com/afriscic/BarcodeScanning.Native.Maui/refs/heads/master/BarcodeScanning.Native.Maui/CameraViewHandler.cs) that 

```
        [nameof(CameraView.CameraEnabled)] = (handler, virtualView) => handler?._cameraManager?.UpdateCameraEnabled(),
```

We see in the [Android CameraManager](https://raw.githubusercontent.com/afriscic/BarcodeScanning.Native.Maui/refs/heads/master/BarcodeScanning.Native.Maui/Platform/Android/CameraManager.cs), this runs:

```
    internal void UpdateCameraEnabled()
    {
        if (_cameraView?.CameraEnabled ?? false)
            Start();
        else
            Stop();
    }
```

Thus, we can implement the fix by simply adding to the Android code a new `ClearPreview()` function and call it on `Start()`:

```
    public void ClearPreview() {
        if (_previewView?.GetChildAt(0) is TextureView textureView) {
            var canvas = textureView.LockCanvas();
            if (canvas != null) {
                canvas.DrawColor(Android.Graphics.Color.Black);
                textureView.UnlockCanvasAndPost(canvas);
            }
        }
    }
```

```
    internal void Start()
    {
        ClearPreview();
```

### CONCLUSION
This is a minimal quick safe upgrade to an already great package that improves the visual experience on Android with minimal code changes. 

Thanks again for building and maintaining this package!