### PR TITLE
Finalize Windows support using zxing.cpp

### DIFF
--- a/BarcodeScanning.Native.Maui/BarcodeScanning.Native.Maui.csproj
+++ b/BarcodeScanning.Native.Maui/BarcodeScanning.Native.Maui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst;</TargetFrameworks>
-		<!--TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks-->
+		<TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>

--- a/BarcodeScanning.Native.Maui/Platform/Windows/BarcodeView.cs
+++ b/BarcodeScanning.Native.Maui/Platform/Windows/BarcodeView.cs
@@ -2,6 +2,7 @@
 
 namespace BarcodeScanning;
 
-public class BarcodeView : Grid
+public partial class BarcodeView : Grid
 {
+
 }

--- a/BarcodeScanning.Native.Maui/Platform/Windows/Extensions.cs
+++ b/BarcodeScanning.Native.Maui/Platform/Windows/Extensions.cs
@@ -1,0 +1,60 @@
+﻿using ZXingCpp;
+
+namespace BarcodeScanning;
+
+public static partial class Extensions
+{
+    public static BarcodeResult AsBarcodeResult(this Barcode barcode, Size? imageSize = null, Size? previewSize = null)
+    {
+        RectF imageRect = CalculateBoundingBox(barcode.Position);
+        RectF previewRect = RectF.Zero;
+
+        if (imageSize.HasValue && previewSize.HasValue && imageRect != RectF.Zero)
+        {
+            previewRect = TransformToPreviewCoordinates(imageRect, imageSize.Value, previewSize.Value);
+        }
+
+        return new BarcodeResult
+        {
+            BarcodeFormat = Methods.ConvertFromZxingFormats(barcode.Format),
+            DisplayValue = barcode.Text,
+            RawValue = barcode.Text,
+            RawBytes = barcode.Bytes ?? [],
+            BarcodeType = BarcodeTypes.Unknown,
+            ImageBoundingBox = imageRect,
+            PreviewBoundingBox = previewRect
+        };
+    }
+
+    private static RectF CalculateBoundingBox(Position position)
+    {
+        //Ensures rotated barcodes are also fully contained in the bounding box
+        var leftX = Math.Min(Math.Min(position.TopLeft.X, position.BottomLeft.X), Math.Min(position.TopRight.X, position.BottomRight.X));
+        var topY = Math.Min(Math.Min(position.TopLeft.Y, position.TopRight.Y), Math.Min(position.BottomLeft.Y, position.BottomRight.Y));
+
+        var rightX = Math.Max(Math.Max(position.TopRight.X, position.BottomRight.X), Math.Max(position.TopLeft.X, position.BottomLeft.X));
+        var bottomY = Math.Max(Math.Max(position.BottomLeft.Y, position.BottomRight.Y), Math.Max(position.TopLeft.Y, position.TopRight.Y));
+
+        return new RectF(leftX, topY, rightX - leftX, bottomY - topY);
+    }
+
+    private static RectF TransformToPreviewCoordinates(RectF imageRect, Size imageSize, Size previewSize)
+    {
+        // Different scaling between preview and image
+        var scaleX = (float)(previewSize.Width / imageSize.Width);
+        var scaleY = (float)(previewSize.Height / imageSize.Height);
+
+        // Ensure the the bounding box has the right size
+        var scale = Math.Max(scaleX, scaleY);
+
+        var offsetX = (float)((previewSize.Width - (imageSize.Width * scale)) / 2);
+        var offsetY = (float)((previewSize.Height - (imageSize.Height * scale)) / 2);
+
+        return new RectF(
+            (imageRect.X * scale) + offsetX,
+            (imageRect.Y * scale) + offsetY,
+            imageRect.Width * scale,
+            imageRect.Height * scale
+        );
+    }
+}

--- a/BarcodeScanning.Native.Maui/Platform/Windows/Methods.cs
+++ b/BarcodeScanning.Native.Maui/Platform/Windows/Methods.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using Windows.Graphics.Imaging;
-using ZXingCpp;
 
 namespace BarcodeScanning;
 
@@ -56,7 +55,7 @@ public static partial class Methods
         return formats;
     }
 
-    private static BarcodeFormats ConvertFromZxingFormats(ZXingCpp.BarcodeFormats format)
+    internal static BarcodeFormats ConvertFromZxingFormats(ZXingCpp.BarcodeFormats format)
     {
         return format switch
         {

--- a/BarcodeScanning.Test/BarcodeScanning.Test.csproj
+++ b/BarcodeScanning.Test/BarcodeScanning.Test.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-		<!--TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks-->
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 
 		<!-- Note for MacCatalyst:
 		The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.

--- a/BarcodeScanning.Test/Properties/launchSettings.json
+++ b/BarcodeScanning.Test/Properties/launchSettings.json
@@ -1,8 +1,20 @@
 {
-  "profiles": {
-    "Windows Machine": {
-      "commandName": "Project",
-      "nativeDebugging": false
+    "profiles": {
+        "Windows Machine": {
+            "commandName": "Project",
+            "nativeDebugging": false
+        },
+        "Msix": {
+            "commandName": "MsixPackage",
+            "commandLineArgs": "", 
+            "alwaysReinstallApp": false, 
+            "remoteDebugEnabled": false, 
+            "allowLocalNetworkLoopbackProperty": true,
+            "authenticationMode": "Windows", 
+            "doNotLaunchApp": false, 
+            "remoteDebugMachine": "", 
+            "nativeDebugging": false 
+        }
     }
   }
 }


### PR DESCRIPTION
I used the initial Windows implementation and brought it to a working state.

The key improvements include:
- Fixed conversion of detected barcodes into the package’s barcode class
- Updated camera handling to avoid concurrent operations
- added preview tracking (bounding box) for windows

Related Issue: #62 

Off-topic: iOS appears to function correctly on my device.