### PR TITLE
fix #101 chose default camera, get more specific if position is wrong

### DIFF
--- a/BarcodeScanning.Native.Maui/Platform/MaciOS/CameraManager.cs
+++ b/BarcodeScanning.Native.Maui/Platform/MaciOS/CameraManager.cs
@@ -132,19 +132,22 @@ internal class CameraManager : IDisposable
     {
         _dispatchQueue?.DispatchBarrierAsync(() =>
         {
-            AVCaptureDevice? newDevice = null;
-            if (_cameraView?.CameraFacing == CameraFacing.Front)
-            {
-                newDevice = AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInWideAngleCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Front);
-            }
-            else
-            {
-                newDevice = AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInTripleCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
-                newDevice ??= AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInDualWideCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
-                newDevice ??= AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInDualCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
-                newDevice ??= AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInWideAngleCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
-            }
-            newDevice ??= AVCaptureDevice.GetDefaultDevice(AVMediaTypes.Video);
+			AVCaptureDevice? newDevice = AVCaptureDevice.GetDefaultDevice(AVMediaTypes.Video);
+			var facing = newDevice.Position == AVCaptureDevicePosition.Back ? CameraFacing.Back : CameraFacing.Front;
+			if (facing != _cameraView?.CameraFacing)
+			{
+				if (_cameraView?.CameraFacing != CameraFacing.Front)
+				{
+					newDevice = AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInWideAngleCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Front);
+				}
+				else
+				{
+					newDevice = AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInTripleCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
+					newDevice ??= AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInDualWideCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
+					newDevice ??= AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInDualCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
+					newDevice ??= AVCaptureDevice.GetDefaultDevice(AVCaptureDeviceType.BuiltInWideAngleCamera, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
+				}
+			}
 
             if (newDevice is null || _captureDevice == newDevice)
                 return;


### PR DESCRIPTION
#101 
It seems on some iPhone (12/13), the picking order of captureDevices would provide suboptimal captureDevices e.g. DualWideCamera on iPhone12, where InWideAngleCamera would be better. 
Instead of chosing a specific deviceType, we use the system default and only pick if position (front/back) is wrong. This becomes neccessary bc. of the overloads of getDefaultDevice