### PR TITLE
Add OnCameraPreviewReady event

### DIFF
--- a/BarcodeScanning.Native.Maui/Platform/Android/CameraManager.cs
+++ b/BarcodeScanning.Native.Maui/Platform/Android/CameraManager.cs
@@ -110,6 +110,7 @@ internal class CameraManager : IDisposable
 
     internal void Start()
     {
+        _cameraView?.ResetCameraPreviewReady();
         _previewView?.Controller = null;
 
         for (int i = 0; i < _previewView?.ChildCount; i++)

--- a/BarcodeScanning.Native.Maui/Platform/Android/CameraStateObserver.cs
+++ b/BarcodeScanning.Native.Maui/Platform/Android/CameraStateObserver.cs
@@ -38,7 +38,10 @@ internal class CameraStateObserver : Java.Lang.Object, IObserver
                 _cameraManager?.OpenedCameraState = cameraState;
 
                 if (cameraState.GetType() == CameraState.Type.Open)
+                {
                     _cameraManager?.UpdateZoomFactor();
+                    _cameraView?.TriggerCameraPreviewReady();
+                }
             }
         }
     }

--- a/BarcodeScanning.Native.Maui/Platform/MaciOS/CameraManager.cs
+++ b/BarcodeScanning.Native.Maui/Platform/MaciOS/CameraManager.cs
@@ -74,7 +74,8 @@ internal class CameraManager : IDisposable
     }
 
     internal void Start()
-{ 
+    {
+        _cameraView?.ResetCameraPreviewReady();
         UpdateCamera();
 
         _dispatchQueue?.DispatchBarrierAsync(() =>
@@ -104,6 +105,8 @@ internal class CameraManager : IDisposable
             UpdateZoomFactor();
 
             _barcodeView?.UpdateOrientation();
+
+            _cameraView?.TriggerCameraPreviewReady();
         });
     }
 

--- a/BarcodeScanning.Native.Maui/Shared/OnCameraPreviewReadyEventArg.cs
+++ b/BarcodeScanning.Native.Maui/Shared/OnCameraPreviewReadyEventArg.cs
@@ -1,0 +1,5 @@
+namespace BarcodeScanning;
+
+public class OnCameraPreviewReadyEventArg : EventArgs
+{
+}


### PR DESCRIPTION
## Summary

Adds a new `OnCameraPreviewReady` event and `OnCameraPreviewReadyCommand` bindable property to `CameraView`, fired once when the camera preview becomes ready.

Closes #194

## Motivation

There is currently no public API to know when the camera preview is actually rendering. Users resort to fragile workarounds like fixed `Task.Delay` or monitoring `CurrentZoomFactor` via `PropertyChanged` to hide loading overlays at the right moment.

## Changes

- **New `OnCameraPreviewReadyEventArg`** — simple EventArgs subclass (follows existing pattern)
- **`CameraView`** — new event, bindable command, and internal trigger method with a guard flag ensuring it fires only once per camera session (reset on `Start`)
- **Android** — fires in `CameraStateObserver.OnChanged()` when `CameraState.Type.Open` is reached
- **iOS/macOS** — fires at the end of the `Start()` dispatch block after session starts running

## Usage

```xml
<scanner:CameraView OnCameraPreviewReady="OnCameraPreviewReady" />
```

```csharp
// Event
cameraView.OnCameraPreviewReady += (s, e) => { /* hide overlay */ };

// Or via command binding
OnCameraPreviewReadyCommand="{Binding CameraReadyCommand}"
```